### PR TITLE
Fix broken link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 **WARNING**: This repository is obsolete. The Structural Imbalance demo is now maintained in
-`dwavesystems/demos <https://github.com/dwavesystems/demos/tree/master/structural-imbalance>`_.
+`dwavesystems/demos <https://github.com/dwave-examples/structural-imbalance>`_.
 
 .. image:: https://circleci.com/gh/dwavesystems/structural-imbalance-demo.svg?style=svg
     :target: https://circleci.com/gh/dwavesystems/structural-imbalance-demo


### PR DESCRIPTION
I get a 404 error from the current link:

![image](https://user-images.githubusercontent.com/34041130/69366822-e6a6e800-0c4b-11ea-814a-661071df6415.png)
