### PR TITLE
Re-enable tests with path separator characters

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -25,17 +25,17 @@ class IntegrationTests(unittest.TestCase):
     def runDemo(self, hardware):
         demo_file = os.path.join(project_dir, 'demo.py')
         output = subprocess.check_output([sys.executable, demo_file, hardware])
-        return str(output)
+        return output.decode("utf-8")
 
     def test_structural_imbalance_cpu(self):
 
         output = self.runDemo("cpu")
-        output = str(output).upper()
+        output = output.upper()
         if os.getenv('DEBUG_OUTPUT'):
             print("Example output \n" + output)
 
-        # with self.subTest(msg="Verify if output contains 'Created CSV file: Results/Global/Structural Imbalance.csv' \n"):
-        #     self.assertIn("Created CSV file: Results/Global/Structural Imbalance.csv".upper(), output)
+        with self.subTest(msg="Verify if output contains 'Created CSV file: Results/Global/Structural Imbalance.csv' \n"):
+            self.assertIn("Created CSV file: Results/Global/Structural Imbalance.csv".upper().replace("/", os.path.sep), output)
         with self.subTest(msg="Verify if output contains 'Running demo on cpu' \n"):
             self.assertIn("Running demo on cpu".upper(), output)
         with self.subTest(msg="Verify if error string contains in output \n"):
@@ -46,12 +46,12 @@ class IntegrationTests(unittest.TestCase):
     def test_structural_imbalance_qpu(self):
         
         output = self.runDemo("qpu")
-        output = str(output).upper()
+        output = output.upper()
         if os.getenv('DEBUG_OUTPUT'):
             print("Example output \n" + output)
 
-        # with self.subTest(msg="Verify if output contains 'Created CSV file: Results/Global/Structural Imbalance.csv' \n"):
-        #     self.assertIn("Created CSV file: Results/Global/Structural Imbalance.csv".upper(), output)
+        with self.subTest(msg="Verify if output contains 'Created CSV file: Results/Global/Structural Imbalance.csv' \n"):
+            self.assertIn("Created CSV file: Results/Global/Structural Imbalance.csv".upper().replace("/", os.path.sep), output)
         with self.subTest(msg="Verify if output contains 'Running demo on qpu' \n"):
             self.assertIn("Running demo on qpu".upper(), output)
         with self.subTest(msg="Verify if error string contains in output \n"):


### PR DESCRIPTION
Re-enable the commented-out tests that were not working on Windows.
The fix is to use `os.path.sep` in the comparison and to properly decode
the bytes output of `subprocess.check_output`.  Tested on Windows and
Linux.

Closes #27.