### PR TITLE
Allow tests to run when QPU solver not available

### DIFF
--- a/dwave_structural_imbalance_demo/interfaces.py
+++ b/dwave_structural_imbalance_demo/interfaces.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from functools import lru_cache
 
 import networkx as nx
 
@@ -8,6 +9,8 @@ from neal import SimulatedAnnealingSampler
 from dwave.system.composites import EmbeddingComposite
 from dwave.system.samplers import DWaveSampler
 import dwave.cloud.exceptions
+from dwave.cloud import Client
+from dwave.cloud.exceptions import ConfigFileError
 
 from dwave_structural_imbalance_demo.mmp_network import global_signed_social_network
 
@@ -17,6 +20,18 @@ if dnx._PY2:
 else:
     def iteritems(d): return d.items()
 
+
+@lru_cache(maxsize=None)
+def qpu_available():
+    """Check whether QPU solver is available"""
+    try:
+        with Client.from_config() as client:
+            solver = client.get_solver(qpu=True)
+    except (ConfigFileError, ValueError) as e:
+        return False
+    else:
+        return True
+        
 
 class GlobalSignedSocialNetwork(object):
     """A class encapsulating access to graphs from the Stanford Militants Mapping Project.

--- a/dwave_structural_imbalance_demo/interfaces.py
+++ b/dwave_structural_imbalance_demo/interfaces.py
@@ -1,5 +1,4 @@
 from collections import OrderedDict
-from functools import lru_cache
 
 import networkx as nx
 
@@ -9,8 +8,6 @@ from neal import SimulatedAnnealingSampler
 from dwave.system.composites import EmbeddingComposite
 from dwave.system.samplers import DWaveSampler
 import dwave.cloud.exceptions
-from dwave.cloud import Client
-from dwave.cloud.exceptions import ConfigFileError
 
 from dwave_structural_imbalance_demo.mmp_network import global_signed_social_network
 
@@ -20,18 +17,6 @@ if dnx._PY2:
 else:
     def iteritems(d): return d.items()
 
-
-@lru_cache(maxsize=None)
-def qpu_available():
-    """Check whether QPU solver is available"""
-    try:
-        with Client.from_config() as client:
-            solver = client.get_solver(qpu=True)
-    except (ConfigFileError, ValueError) as e:
-        return False
-    else:
-        return True
-        
 
 class GlobalSignedSocialNetwork(object):
     """A class encapsulating access to graphs from the Stanford Militants Mapping Project.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,16 @@
+from functools import lru_cache
+
+from dwave.cloud import Client
+from dwave.cloud.exceptions import ConfigFileError
+
+@lru_cache(maxsize=None)
+def qpu_available():
+    """Check whether QPU solver is available"""
+    try:
+        with Client.from_config() as client:
+            solver = client.get_solver(qpu=True)
+    except (ConfigFileError, ValueError) as e:
+        return False
+    else:
+        return True
+        

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -18,6 +18,8 @@ import time
 import os
 import sys
 
+from dwave_structural_imbalance_demo.interfaces import qpu_available
+
 project_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 class IntegrationTests(unittest.TestCase):
@@ -43,6 +45,7 @@ class IntegrationTests(unittest.TestCase):
         with self.subTest(msg="Verify if warning string contains in output \n"):
             self.assertNotIn("WARNING", output)
 
+    @unittest.skipUnless(qpu_available(), "requires QPU")
     def test_structural_imbalance_qpu(self):
         
         output = self.runDemo("qpu")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -18,7 +18,7 @@ import time
 import os
 import sys
 
-from dwave_structural_imbalance_demo.interfaces import qpu_available
+from . import qpu_available
 
 project_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -16,7 +16,8 @@ import unittest
 from random import randint, choice
 import jsonschema
 
-from dwave_structural_imbalance_demo.interfaces import GlobalSignedSocialNetwork, qpu_available
+from . import qpu_available
+from dwave_structural_imbalance_demo.interfaces import GlobalSignedSocialNetwork
 from dwave_structural_imbalance_demo.json_schema import json_schema
 
 

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -16,46 +16,58 @@ import unittest
 from random import randint, choice
 import jsonschema
 
-from dwave_structural_imbalance_demo.interfaces import GlobalSignedSocialNetwork
+from dwave_structural_imbalance_demo.interfaces import GlobalSignedSocialNetwork, qpu_available
 from dwave_structural_imbalance_demo.json_schema import json_schema
 
 
 class TestInterfaces(unittest.TestCase):
-    gssn_qpu = GlobalSignedSocialNetwork(True)
-    gssn_cpu = GlobalSignedSocialNetwork(False)
+
+    @classmethod
+    def setUpClass(cls):
+        if qpu_available():
+            cls.gssn_qpu = GlobalSignedSocialNetwork(True)
+        cls.gssn_cpu = GlobalSignedSocialNetwork(False)
 
     def test_get_node_link_data_output(self):
         subgroup = choice(['Global', 'Syria', 'Iraq'])
         year = randint(2009, 2016)
-        output = self.gssn_qpu.get_node_link_data(subgroup, year)
+        output = self.gssn_cpu.get_node_link_data(subgroup, year)
         jsonschema.validate(output, json_schema)
 
-    def test_solve_structural_imbalance_output(self):
+    @unittest.skipUnless(qpu_available(), "requires QPU")
+    def test_solve_structural_imbalance_output_qpu(self):
         subgroup = 'Syria'
         year = 2013
-        output = self.gssn_qpu.solve_structural_imbalance(subgroup, year)
-        jsonschema.validate(output, json_schema)
         output = self.gssn_cpu.solve_structural_imbalance(subgroup, year)
         jsonschema.validate(output, json_schema)
 
-    def test_whole_embedding(self):
+    def test_solve_structural_imbalance_output_cpu(self):
+        subgroup = 'Syria'
+        year = 2013
+        output = self.gssn_cpu.solve_structural_imbalance(subgroup, year)
+        jsonschema.validate(output, json_schema)
+
+    @unittest.skipUnless(qpu_available(), "requires QPU")
+    def test_whole_embedding_qpu(self):
         self.gssn_qpu.solve_structural_imbalance()
+
+    def test_whole_embedding_cpu(self):
         self.gssn_cpu.solve_structural_imbalance()
 
     def test_invalid_subgroup(self):
         subgroup = 'unknown_subgroup'
-        self.assertRaises(KeyError, self.gssn_qpu.get_node_link_data, subgroup)
-        self.assertRaises(KeyError, self.gssn_qpu.solve_structural_imbalance, subgroup)
+        self.assertRaises(KeyError, self.gssn_cpu.get_node_link_data, subgroup)
+        self.assertRaises(KeyError, self.gssn_cpu.solve_structural_imbalance, subgroup)
 
     def test_invalid_year(self):
         year = 'not_an_integer'
-        self.assertRaises(ValueError, self.gssn_qpu.get_node_link_data, year=year)
-        self.assertRaises(ValueError, self.gssn_qpu.solve_structural_imbalance, year=year)
+        self.assertRaises(ValueError, self.gssn_cpu.get_node_link_data, year=year)
+        self.assertRaises(ValueError, self.gssn_cpu.solve_structural_imbalance, year=year)
 
     def test_year_zero(self):
         year = 0
-        output = self.gssn_qpu.get_node_link_data(year=year)
+        output = self.gssn_cpu.get_node_link_data(year=year)
         for result in output['results']:
             self.assertFalse(result['nodes'])
             self.assertFalse(result['links'])
-        self.assertRaises(ValueError, self.gssn_qpu.solve_structural_imbalance, year=year)
+        self.assertRaises(ValueError, self.gssn_cpu.solve_structural_imbalance, year=year)


### PR DESCRIPTION
Add a caching function `qpu_available()` that checks the client for a QPU solver (please double-check my logic in this function).  Update the unit tests to skip test cases that require the QPU solver.  Some refactoring was needed for `test_integration.py`: tests that do not involve the solver were switched to use the CPU instead of QPU.  Otherwise, tests were broken out into CPU and QPU separately, skipping the QPU tests if necessary.

Tested with and without solver API key and seems to work in each case.

Closes #29.