### PR TITLE
Specify pegasus topology for DWaveSampler

### DIFF
--- a/structural_imbalance.py
+++ b/structural_imbalance.py
@@ -65,7 +65,7 @@ def main(sampler_type, region, show):
         params = dict(num_reads=100,
                       chain_strength=2.0,
                       )
-        sampler = EmbeddingComposite(DWaveSampler())
+        sampler = EmbeddingComposite(DWaveSampler(solver=dict(topology__type='pegasus')))
 
     else:
         raise RuntimeError("unknown solver type")


### PR DESCRIPTION
In attempt to resolve "no embedding found" error from CI.

Closes #33 (hopefully)