### PR TITLE
Unpin and upgrade Ocean SDK to 3.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dwave-ocean-sdk==2.1.1
+dwave-ocean-sdk>=3.0.0
 click
 
 matplotlib==3.1.3; python_version>'3.5'


### PR DESCRIPTION
Should resolve issues with retrieving a DWaveSampler that is not compatible with the problem being solved.

Closes #33 and replaces PR #34.