### PR TITLE
Graphics change for the Leap IDE

### DIFF
--- a/structural_imbalance.py
+++ b/structural_imbalance.py
@@ -84,7 +84,7 @@ def main(sampler_type, region, show):
         plt.show()
     else:
         filename = 'stuctural imbalance {} {}.png'.format(sampler_type, region)
-        plt.savefig(filename, facecolor='white', dpi=500)
+        plt.savefig(filename, facecolor='white', bbox_inches='tight')
         plt.clf()
 
 

--- a/structural_imbalance.py
+++ b/structural_imbalance.py
@@ -84,7 +84,7 @@ def main(sampler_type, region, show):
         plt.show()
     else:
         filename = 'stuctural imbalance {} {}.png'.format(sampler_type, region)
-        plt.savefig(filename, facecolor='white', bbox_inches='tight')
+        plt.savefig(filename, facecolor='white')
         plt.clf()
 
 


### PR DESCRIPTION
In the Leap IDE the graphs are really big when they save as a png. I couldn't zoom out on the png, but removing `dpi=500` fixed the scaling. 